### PR TITLE
Fix README license typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ If you’d like to contribute:
 
 ## ⚖️ License
 
-This project is open-source but may is definitely subject to **Cosmere IP restrictions**. Thank you Brandon Sanderson, and Dragonsteel for all of your work!  
+This project is open-source but is definitely subject to **Cosmere IP restrictions**. Thank you Brandon Sanderson, and Dragonsteel for all of your work!
 Please do not redistribute standalone modules without credit and attribution.  
 This is a fan project not affiliated with Brandon Sanderson or Dragonsteel Entertainment.
 


### PR DESCRIPTION
## Summary
- fix the license sentence in the README

## Testing
- `grep -n open-source README.md`

------
https://chatgpt.com/codex/tasks/task_e_684331841040832aa068dd10064e2205