### PR TITLE
Consolidate Mod Startup

### DIFF
--- a/CosmereCore/CosmereCore/CosmereCore.cs
+++ b/CosmereCore/CosmereCore/CosmereCore.cs
@@ -12,8 +12,7 @@ namespace CosmereCore {
     [StaticConstructorOnStartup]
     public static class ModStartup {
         static ModStartup() {
-            Log.Important($"Build Rev: {BuildInfo.REVISION} @ {BuildInfo.BUILD_TIME}. DebugMode={CosmereSettings.debugMode} LogLevel={CosmereSettings.logLevel}");
-            new Harmony("Cryptiklemur.Cosmere.Core").PatchAll();
+            Startup.Initialize("Cryptiklemur.Cosmere.Core");
         }
     }
 }

--- a/CosmereFramework/CosmereFramework/CosmereFramework.cs
+++ b/CosmereFramework/CosmereFramework/CosmereFramework.cs
@@ -39,8 +39,7 @@ namespace CosmereFramework {
     [StaticConstructorOnStartup]
     public static class ModStartup {
         static ModStartup() {
-            Log.Important($"Build Rev: {BuildInfo.REVISION} @ {BuildInfo.BUILD_TIME}. DebugMode={CosmereFramework.CosmereSettings.debugMode} LogLevel={CosmereFramework.CosmereSettings.logLevel}");
-            new Harmony("cryptiklemur.cosmere.core").PatchAll();
+            Startup.Initialize("cryptiklemur.cosmere.core");
         }
     }
 }

--- a/CosmereFramework/CosmereFramework/Startup.cs
+++ b/CosmereFramework/CosmereFramework/Startup.cs
@@ -1,0 +1,8 @@
+namespace CosmereFramework {
+    public static class Startup {
+        public static void Initialize(string harmonyId) {
+            Log.Important($"Build Rev: {BuildInfo.REVISION} @ {BuildInfo.BUILD_TIME}. DebugMode={CosmereFramework.CosmereSettings.debugMode} LogLevel={CosmereFramework.CosmereSettings.logLevel}");
+            new HarmonyLib.Harmony(harmonyId).PatchAll();
+        }
+    }
+}

--- a/CosmereMetals/CosmereMetals/CosmereMetals.cs
+++ b/CosmereMetals/CosmereMetals/CosmereMetals.cs
@@ -12,8 +12,7 @@ namespace CosmereMetals {
     [StaticConstructorOnStartup]
     public static class ModStartup {
         static ModStartup() {
-            Log.Important($"Build Rev: {BuildInfo.REVISION} @ {BuildInfo.BUILD_TIME}. DebugMode={CosmereSettings.debugMode} LogLevel={CosmereSettings.logLevel}");
-            new Harmony("Cryptiklemur.Cosmere.Metals").PatchAll();
+            Startup.Initialize("Cryptiklemur.Cosmere.Metals");
         }
     }
 }

--- a/CosmereScadrial/CosmereScadrial/CosmereScadrial.cs
+++ b/CosmereScadrial/CosmereScadrial/CosmereScadrial.cs
@@ -18,8 +18,7 @@ namespace CosmereScadrial {
     [StaticConstructorOnStartup]
     public static class ModStartup {
         static ModStartup() {
-            Log.Important($"Build Rev: {BuildInfo.REVISION} @ {BuildInfo.BUILD_TIME}. DebugMode={CosmereSettings.debugMode} LogLevel={CosmereSettings.logLevel}");
-            new Harmony("cryptiklemur.cosmere.scadrial").PatchAll();
+            Startup.Initialize("cryptiklemur.cosmere.scadrial");
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a Startup helper in the framework
- use the helper across module startup classes

## Testing
- `dotnet build Cosmere.sln -c Release` *(fails: reference assemblies for .NET Framework 4.8.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_684359655020832aa6fe5c75f34ecc7b