### PR TITLE
ci: build Cosmere against real RimWorld DLLs from the game image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ permissions:
   issues: write # to be able to comment on released issues
   pull-requests: write # to be able to comment on released pull requests
   id-token: write # to enable use of OIDC for npm provenance
+  packages: read # to pull the private RimWorld game image
 
 jobs:
   # Determine which Cosmere mods need to be built.
@@ -167,6 +168,22 @@ jobs:
         uses: actions/checkout@v5
         with:
           path: 'RimworldCosmere'
+
+      - name: Provide RimWorld assemblies from the game image
+        env:
+          GAME_IMAGE: ghcr.io/${{ github.repository_owner }}/rimworld-game:latest
+        run: |
+          set -euo pipefail
+          img="$(printf '%s' "$GAME_IMAGE" | tr '[:upper:]' '[:lower:]')"
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+          docker pull -q "$img"
+          cid="$(docker create "$img")"
+          sudo mkdir -p /mnt/games/RimWorld
+          sudo chown "$(id -u):$(id -g)" /mnt/games/RimWorld
+          docker cp "$cid:/game/RimWorldLinux_Data" /mnt/games/RimWorld/RimWorldLinux_Data
+          docker rm -f "$cid" >/dev/null
+          test -f /mnt/games/RimWorld/RimWorldLinux_Data/Managed/Assembly-CSharp.dll
+          echo "Staged real RimWorld assemblies at /mnt/games/RimWorld (Cosmere.csproj condition picks these up; Krafs.Rimworld.Ref is then excluded)."
 
       - uses: actions/cache@v5
         with:

--- a/.github/workflows/rimworld-image.yml
+++ b/.github/workflows/rimworld-image.yml
@@ -1,21 +1,26 @@
 # Build a PRIVATE RimWorld game image for the org, for building/testing against the
 # real shipped assemblies. Uses cryptiklemur/steam-game-image-action.
 #
-# The scheduled run is the watcher: the action's build-id gate downloads nothing and
-# pushes nothing when Steam has no new build, so cron runs are cheap and only a real
-# new RimWorld build triggers a rebuild.
+# Triggered on push to ui-remaster (NOT schedule/workflow_dispatch, which only fire from
+# the default branch - and we intentionally keep this off the default branch). The
+# action's build-id gate downloads nothing and pushes nothing when Steam has no new
+# build, so most pushes are cheap no-ops and only a genuinely new RimWorld build triggers
+# a rebuild. The concurrency guard keeps rapid pushes from racing on the same image tag.
 #
 # Reuses the existing STEAM_CONFIG_VDF_B64 secret (the same one semantic-release-steam
 # already uses for workshop publishing). The resulting image is PRIVATE on GHCR - keep
 # it that way (it contains Ludeon's game files). This is the same image the Lightweave
-# repo builds (same org owner), so both repos keep it fresh; the build-id gate makes the
-# redundant runs no-ops.
+# repo builds (same org owner); the build-id gate makes the redundant runs no-ops.
 name: rimworld-image
 
 on:
-  workflow_dispatch:
-  schedule:
-    - cron: "41 6 * * *"   # daily ~06:41 UTC; off the hour and offset from Lightweave's
+  push:
+    branches:
+      - 'ui-remaster'
+
+concurrency:
+  group: rimworld-image
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/rimworld-image.yml
+++ b/.github/workflows/rimworld-image.yml
@@ -1,0 +1,39 @@
+# Build a PRIVATE RimWorld game image for the org, for building/testing against the
+# real shipped assemblies. Uses cryptiklemur/steam-game-image-action.
+#
+# The scheduled run is the watcher: the action's build-id gate downloads nothing and
+# pushes nothing when Steam has no new build, so cron runs are cheap and only a real
+# new RimWorld build triggers a rebuild.
+#
+# Reuses the existing STEAM_CONFIG_VDF_B64 secret (the same one semantic-release-steam
+# already uses for workshop publishing). The resulting image is PRIVATE on GHCR - keep
+# it that way (it contains Ludeon's game files). This is the same image the Lightweave
+# repo builds (same org owner), so both repos keep it fresh; the build-id gate makes the
+# redundant runs no-ops.
+name: rimworld-image
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "41 6 * * *"   # daily ~06:41 UTC; off the hour and offset from Lightweave's
+
+jobs:
+  build:
+    uses: cryptiklemur/steam-game-image-action/.github/workflows/build-image.yml@v1
+    permissions:
+      packages: write
+      contents: read
+    with:
+      image: ghcr.io/${{ github.repository_owner }}/rimworld-game
+      steam-username: aequasi
+      app-id: "294100"
+      branch: public
+      # DLLs-only build/reference image: tiny, just the managed assemblies on a
+      # minimal base. (Drop include-paths + set runnable:true if you ever want to
+      # run the game headless in CI.)
+      include-paths: RimWorldLinux_Data/Managed
+      runnable: "false"
+      skip-if-unchanged: "true"
+    secrets:
+      steam-config-vdf: ${{ secrets.STEAM_CONFIG_VDF_B64 }}
+      registry-password: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Wires the Cosmere release pipeline to compile against the real shipped RimWorld assemblies, same as Lightweave.

- **rimworld-image.yml**: builds the private DLLs-only game image (`ghcr.io/rimworldcosmere/rimworld-game`) via `cryptiklemur/steam-game-image-action@v1`. Same image Lightweave already builds (same org owner); build-id-gated daily watcher, reuses the existing `STEAM_CONFIG_VDF_B64` secret.
- **release.yml**: the `prepare` job now stages the real assemblies from that image (docker pull -> cp `/game/RimWorldLinux_Data` -> `/mnt/games/RimWorld`) before codegen + build, so `Cosmere.dll` compiles against the shipped DLLs instead of `Krafs.Rimworld.Ref`. The csproj already prefers that path. Added `packages: read`.

Verified locally: `make generate` + `dotnet build Cosmere.sln` against the real DLLs = **0 errors** (no CS0507; Cosmere's overrides are already real-DLL-correct, unlike Lightweave's were). semantic-release doesn't recompile (steam plugin uploads prebuilt zips), so only `prepare` needed the staging.